### PR TITLE
refactor(media): 重构平台站标加载与缩略图管理逻辑

### DIFF
--- a/MediaController.cs
+++ b/MediaController.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Text.RegularExpressions;
 using Windows.Media.Control;
 using SkiaSharp;
@@ -17,6 +17,8 @@ namespace NotchPeninsula
         public bool IsPlaying { get; private set; } = false;
         public bool IsActive { get; private set; } = false;
         public SKBitmap? Thumbnail { get; private set; }
+        // 当前 Thumbnail 是否来自 MediaLogoProvider 的共享缓存（由提供方持有，替换时不得 Dispose）
+        private bool _thumbnailIsShared;
 
         private GlobalSystemMediaTransportControlsSessionManager? _manager;
         private GlobalSystemMediaTransportControlsSession? _currentSession;
@@ -44,6 +46,14 @@ namespace NotchPeninsula
         public async Task ForceRefresh()
         {
             if (_manager != null) await UpdateSession(_manager);
+        }
+
+        // 统一替换缩略图：共享站标由 MediaLogoProvider 持有，绝不能 Dispose；仅 SMTC 解码出的才归本类所有
+        private void SetThumbnail(SKBitmap? newThumb, bool shared)
+        {
+            if (!_thumbnailIsShared) Thumbnail?.Dispose();
+            Thumbnail = newThumb;
+            _thumbnailIsShared = shared;
         }
 
         private async Task UpdateSession(GlobalSystemMediaTransportControlsSessionManager manager)
@@ -124,8 +134,7 @@ namespace NotchPeninsula
                 Title = "No Media";
                 Artist = "";
                 IsPlaying = false;
-                Thumbnail?.Dispose();
-                Thumbnail = null;
+                SetThumbnail(null, false);
             }
         }
 
@@ -152,12 +161,11 @@ namespace NotchPeninsula
                             : (string.IsNullOrEmpty(props.Artist) ? "" : props.Artist));
 
                     // 统一封面管理：PotPlayer/bilibili 始终用站标；浏览器无 SMTC 封面时用站标兜底
+                    // 站标为共享缓存（shared=true），仅持有引用，替换时不得 Dispose，避免误伤缓存
                     var platformLogo = MediaLogoProvider.GetLogo(_currentSession.SourceAppUserModelId, props.Thumbnail != null);
                     if (platformLogo != null)
                     {
-                        var oldThumb = Thumbnail;
-                        Thumbnail = platformLogo;
-                        oldThumb?.Dispose();
+                        SetThumbnail(platformLogo, true);
                     }
                     else if (props.Thumbnail != null)
                     {
@@ -166,17 +174,15 @@ namespace NotchPeninsula
                             using var stream = await props.Thumbnail.OpenReadAsync();
                             using var dotNetStream = stream.AsStreamForRead();
 
-                            var oldThumb = Thumbnail;
-                            Thumbnail = SKBitmap.Decode(dotNetStream);
-                            oldThumb?.Dispose();
+                            SetThumbnail(SKBitmap.Decode(dotNetStream), false);
                         }
                         catch (Exception ex)
                         {
                             Logger.Error("封面解析失败", ex);
-                            Thumbnail = null;
+                            SetThumbnail(null, false);
                         }
                     }
-                    else Thumbnail = null;
+                    else SetThumbnail(null, false);
                 }
             }
             catch (Exception ex)
@@ -185,7 +191,7 @@ namespace NotchPeninsula
                 Logger.Error("读取媒体属性失败，可能遇到不规范的媒体源", ex);
                 Title = _isPotPlayerSession ? "" : "Unknown";
                 Artist = (_isBilibiliSession || _isPotPlayerSession) ? "" : "Unknown";
-                Thumbnail = null;
+                SetThumbnail(null, false);
             }
 
             // 播放状态的读取也建议加上保护

--- a/MediaLogoProvider.cs
+++ b/MediaLogoProvider.cs
@@ -30,13 +30,40 @@ namespace NotchPeninsula
         ];
 
         // 路径 -> 已解码位图缓存，全进程共享，避免重复 IO + 解码
+        // 与 Renderer 的 QQ 图标一致：只预加载一次，持有共享引用，调用方不得 Dispose
         private static readonly Dictionary<string, SKBitmap> _cache = new(StringComparer.OrdinalIgnoreCase);
+        private static bool _loaded = false;
 
-        // 根据会话 AppUserModelId 返回对应平台站标封面副本；未命中返回 null
+        // 一次性预加载所有站标（参照 QQ 图标的 EnsureIconsLoaded 加载方式）
+        private static void EnsureLoaded()
+        {
+            if (_loaded) return;
+            try
+            {
+                foreach (var rule in PlatformRules)
+                {
+                    var path = Path.Combine(AppContext.BaseDirectory, rule.LogoPath);
+                    if (File.Exists(path))
+                    {
+                        using var stream = File.OpenRead(path);
+                        _cache[rule.LogoPath] = SKBitmap.Decode(stream);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("加载平台封面失败", ex);
+            }
+            finally { _loaded = true; }
+        }
+
+        // 根据会话 AppUserModelId 返回对应平台站标封面（共享缓存引用，调用方不得 Dispose）；未命中返回 null
         // hasThumbnail 表示会话是否提供了 SMTC 封面，Fallback 平台仅在其为空时才使用站标
         public static SKBitmap? GetLogo(string? sourceAppUserModelId, bool hasThumbnail)
         {
             if (string.IsNullOrWhiteSpace(sourceAppUserModelId)) return null;
+
+            EnsureLoaded();
 
             var id = sourceAppUserModelId.ToLowerInvariant();
             foreach (var rule in PlatformRules)
@@ -45,7 +72,7 @@ namespace NotchPeninsula
 
                 // 一旦 AppID 命中即确定应用：Always 始终用站标；Fallback 仅无封面时兜底
                 if (rule.Strategy == CoverStrategy.Always || !hasThumbnail)
-                    return LoadAndCache(rule.LogoPath);
+                    return _cache.TryGetValue(rule.LogoPath, out var bmp) ? bmp : null;
                 return null;
             }
             return null;
@@ -74,27 +101,6 @@ namespace NotchPeninsula
                     return true;
             }
             return false;
-        }
-
-        // 读取并缓存平台站标封面，返回副本避免被调用方 Dispose 时误伤缓存
-        private static SKBitmap? LoadAndCache(string relativePath)
-        {
-            try
-            {
-                if (!_cache.TryGetValue(relativePath, out var bmp))
-                {
-                    var path = Path.Combine(AppContext.BaseDirectory, relativePath);
-                    using var stream = File.OpenRead(path);
-                    bmp = SKBitmap.Decode(stream);
-                    _cache[relativePath] = bmp;
-                }
-                return bmp?.Copy();
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"加载平台封面 {relativePath} 失败", ex);
-                return null;
-            }
         }
     }
 }


### PR DESCRIPTION
1.  新增预加载缓存机制，一次性加载所有平台站标并全局共享
2.  移除重复的单图加载缓存，统一使用共享缓存避免重复解码
3.  新增缩略图共享状态跟踪，正确管理SKBitmap的Dispose生命周期
4.  封装统一的缩略图设置方法，规范资源释放逻辑