### PR TITLE
Just Solo LyricServer 直连（歌词 + 实时频谱）+ 音频捕获独占自愈

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.vsidx
 bin/
 obj/
+publish/

--- a/AudioAnalyzer.cs
+++ b/AudioAnalyzer.cs
@@ -1,10 +1,26 @@
-﻿using NAudio.Wave;
+using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
+using NAudio.Wave;
 
 namespace NotchPeninsula
 {
-    public class AudioAnalyzer
+    /// <summary>
+    /// 系统输出（WASAPI Loopback）实时频谱分析。
+    /// 其它程序以独占模式占用输出设备时，捕获流会被系统断开；这里用常驻看门狗轮询做健康检查
+    /// （单次约 0.04µs，基本免费）并在判定失效时限速重建捕获（单次约 7ms），同时订阅 Core Audio
+    /// 事件在音频环境变化时立即复核，因此恢复延迟通常在 1 个检查周期内。
+    /// </summary>
+    public class AudioAnalyzer : IDisposable
     {
-        private WasapiLoopbackCapture? _capture;
+        // 降采样后的目标采样率，Goertzel 只需在这个低采样率上跑
+        private const int TargetSampleRate = 8000;
+        // 看门狗健康检查周期
+        private const int HealthCheckIntervalMs = 500;
+        // 失效后重建捕获的最小间隔，避免长时间独占期间反复初始化
+        private const int RestartAttemptIntervalMs = 1000;
+        // Loopback 捕获即使静音也会持续送帧，超过该时长没有数据即认为流已失效
+        private const double DataSilenceTimeoutMs = 1500d;
+
         private float[] _frontBars = new float[5];
         private float[] _backBars = new float[5];
         private float[] _tempBars = new float[5];
@@ -17,54 +33,350 @@ namespace NotchPeninsula
         // 用于 AGC 自动增益补偿的峰值追踪
         private float _currentPeak = 0.1f;
 
+        // ===== 捕获生命周期 =====
+        private readonly object _captureLock = new();
+        private WasapiLoopbackCapture? _capture;
+        private volatile bool _restartingCapture; // 本类主动释放旧捕获时，忽略其停止回调
+        private long _lastDataTicks;              // 最后一次收到音频数据（含静音帧）的时间
+
+        private readonly ManualResetEventSlim _checkSignal = new(false); // 事件催促看门狗立即复核
+        private readonly CancellationTokenSource _shutdown = new();
+        private readonly CancellationToken _shutdownToken; // 取自 _shutdown，CTS 被 Dispose 后仍可安全读取
+        private Task? _watchdogTask;
+        private volatile bool _disposed;
+
+        // ===== Core Audio 事件订阅 =====
+        private readonly NotificationClient _notificationClient;
+        private readonly SessionEventsHandler _sessionEvents;
+        private MMDeviceEnumerator? _enumerator;
+        private AudioEndpointVolume? _endpointVolume; // 需持有引用，否则音量回调会被回收
+        private AudioSessionControl? _sessionControl; // 需持有引用，会话断开回调依赖它
+
         public AudioAnalyzer()
         {
-            StartCapture();
+            _shutdownToken = _shutdown.Token;
+            _notificationClient = new NotificationClient(this);
+            _sessionEvents = new SessionEventsHandler(this);
+
+            SubscribeSystemEvents();
+
+            TryStartCapture(); // 首次就被独占占用也没关系，看门狗会持续补救
+
+            // 常驻看门狗：健康时只做极廉价的检查，失效时才重建捕获。
+            // 由 Dispose()（程序退出流程）通过 CancellationToken 停止。
+            _watchdogTask = Task.Factory.StartNew(WatchdogLoop, TaskCreationOptions.LongRunning);
         }
 
-        private void StartCapture()
+        /// <summary>
+        /// 停止看门狗并释放捕获与 Core Audio 订阅。供程序退出流程调用，可重复调用。
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            try
+            {
+                _shutdown.Cancel();
+                _checkSignal.Set();        // 立即唤醒看门狗，让它看到取消
+                _watchdogTask?.Wait(1000); // 等它退出，避免与下面的释放动作并发
+
+                try { _sessionControl?.UnRegisterEventClient(_sessionEvents); } catch { }
+                _sessionControl = null;
+                ReleaseCapture();
+
+                try { _enumerator?.UnregisterEndpointNotificationCallback(_notificationClient); } catch { }
+                _endpointVolume?.Dispose();
+                _endpointVolume = null;
+
+                _checkSignal.Dispose();
+                _shutdown.Dispose();
+                Logger.Info("音频分析器已释放");
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("音频分析器释放资源异常", ex);
+            }
+        }
+
+        // ===================== 捕获初始化 / 恢复 =====================
+
+        private bool TryStartCapture(bool isRetry = false)
+        {
+            lock (_captureLock)
+            {
+                if (_capture != null) return true;
+
+                WasapiLoopbackCapture? capture = null;
+                try
+                {
+                    capture = new WasapiLoopbackCapture(); // 默认捕获系统主混音输出
+                    ConfigureBands(capture.WaveFormat);
+
+                    capture.DataAvailable += OnAudioData;
+                    capture.RecordingStopped += OnRecordingStopped;
+                    capture.StartRecording();
+                }
+                catch (Exception ex)
+                {
+                    // 独占占用期间会按退避反复重试，重试失败只记 Debug，避免刷屏
+                    if (isRetry) Logger.Debug($"音频捕获仍未就绪: {ex.Message}");
+                    else Logger.Error("音频捕获初始化失败，可能被独占占用或无音频设备", ex);
+
+                    try { capture?.Dispose(); } catch { } // 失败时释放半成品，避免退避重试泄漏
+                    return false;
+                }
+
+                _capture = capture;
+                Volatile.Write(ref _lastDataTicks, DateTime.UtcNow.Ticks);
+                RegisterSessionEvents(); // 订阅本进程捕获会话的断开事件
+                return true;
+            }
+        }
+
+        /// <summary>释放旧捕获（幂等），供恢复流程重新初始化。</summary>
+        private void ReleaseCapture()
+        {
+            WasapiLoopbackCapture? capture;
+            lock (_captureLock)
+            {
+                capture = _capture;
+                _capture = null;
+            }
+            if (capture == null) return;
+
+            _restartingCapture = true;
+            try
+            {
+                capture.DataAvailable -= OnAudioData;
+                capture.RecordingStopped -= OnRecordingStopped;
+                capture.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug($"释放音频捕获失败: {ex.Message}");
+            }
+            finally
+            {
+                _restartingCapture = false;
+            }
+
+            _sessionControl = null; // 旧会话随捕获一并销毁
+        }
+
+        /// <summary>
+        /// 由 Core Audio 事件回调或渲染层调用：请求立即复核捕获状态。
+        /// 释放/重建固定在看门狗线程上执行，避免在 COM 回调线程里做耗时操作。
+        /// </summary>
+        public void EnsureCaptureAlive() => RequestCheck();
+
+        /// <summary>
+        /// 唤醒看门狗；Dispose 之后（进程正在退出）静默忽略，避免唤起已释放的同步原语——
+        /// 调用方有渲染线程与 COM 回调线程，异常外逸会终止进程。
+        /// </summary>
+        private void RequestCheck()
+        {
+            if (_disposed) return;
+
+            try
+            {
+                _checkSignal.Set();
+            }
+            catch (ObjectDisposedException)
+            {
+                // 与 Dispose 竞争，进程正在退出，忽略即可
+            }
+        }
+
+        private bool IsCaptureAlive()
+        {
+            var capture = _capture;
+            if (capture == null) return false;
+            if (capture.CaptureState is CaptureState.Stopped or CaptureState.Stopping) return false;
+
+            // Loopback 持续送帧（静音时送静音帧），长时间收不到数据说明流已被系统悄悄断开
+            long silenceMs = (DateTime.UtcNow.Ticks - Volatile.Read(ref _lastDataTicks)) / TimeSpan.TicksPerMillisecond;
+            return silenceMs < DataSilenceTimeoutMs;
+        }
+
+        /// <summary>
+        /// 常驻看门狗：健康时每 500ms 做一次约 0.04µs 的检查；判定失效后重建捕获（约 7ms/次），
+        /// 重建之间至少间隔 2s；被 Core Audio 事件唤醒时跳过限速，立即重建。
+        /// </summary>
+        private void WatchdogLoop()
+        {
+            bool recovering = false;
+            long nextAttemptTicks = 0;
+
+            while (!_shutdownToken.IsCancellationRequested)
+            {
+                try
+                {
+                    bool signaled = _checkSignal.Wait(HealthCheckIntervalMs);
+                    _checkSignal.Reset();
+                    if (_shutdownToken.IsCancellationRequested) break; // 退出前不再动捕获
+
+                    if (IsCaptureAlive())
+                    {
+                        if (recovering)
+                        {
+                            recovering = false;
+                            Logger.Info("音频捕获已恢复");
+                        }
+                        continue;
+                    }
+
+                    if (!recovering)
+                    {
+                        recovering = true;
+                        Logger.Info("音频捕获已断开，等待设备释放后自动恢复");
+                    }
+
+                    // 无事件催促时按最小间隔限速，避免独占期间反复重建捕获
+                    if (!signaled && DateTime.UtcNow.Ticks < nextAttemptTicks) continue;
+
+                    ReleaseCapture();
+                    TryStartCapture(isRetry: true);
+                    nextAttemptTicks = DateTime.UtcNow.Ticks + RestartAttemptIntervalMs * TimeSpan.TicksPerMillisecond;
+                }
+                catch (Exception ex)
+                {
+                    // 单轮异常绝不能让看门狗退出：Task 内的未观察异常会被静默吞掉，
+                    // 看门狗一死频谱就永久失效且无人知晓。丢弃当前捕获后继续下一轮。
+                    Logger.Error("音频看门狗检查异常，已丢弃当前捕获并继续运行", ex);
+                    ReleaseCapture();
+                    Thread.Sleep(HealthCheckIntervalMs); // 异常持续时避免变成紧循环
+                }
+            }
+        }
+
+        private void OnRecordingStopped(object? sender, StoppedEventArgs e)
+        {
+            if (_restartingCapture) return; // 主动重启导致的停止，不算故障
+
+            if (e.Exception != null)
+                Logger.Warn($"音频捕获意外停止: {e.Exception.Message}");
+            else
+                Logger.Warn("音频捕获已停止，等待恢复");
+
+            ClearBars();
+            RequestCheck(); // 释放与重启交给看门狗线程，避免在捕获线程里做耗时操作
+        }
+
+        // ===================== Core Audio 事件订阅 =====================
+
+        private void SubscribeSystemEvents()
         {
             try
             {
-                _capture = new WasapiLoopbackCapture(); // 默认捕获系统主混音输出
-                _channels = _capture.WaveFormat.Channels;
+                var enumerator = new MMDeviceEnumerator();
+                enumerator.RegisterEndpointNotificationCallback(_notificationClient);
 
-                // 核心优化：极速降采样 (Decimation)。比如 48000Hz -> 取每 6 个样本中的 1 个 = 8000Hz
-                _decimationFactor = Math.Max(1, _capture.WaveFormat.SampleRate / 8000);
-                int actualSampleRate = _capture.WaveFormat.SampleRate / _decimationFactor;
+                var device = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                var volume = device.AudioEndpointVolume;
+                volume.OnVolumeNotification += _ => EnsureCaptureAlive();
 
-                // 重新挑选 5 个最具代表性的律动频段，并进行巨大的高频能量补偿
-                // 1. 底鼓 (80Hz) 2. 军鼓/下盘 (250Hz) 3. 人声 (600Hz) 4. 乐器高频 (1500Hz) 5. 极高频/镲片 (3500Hz)
-                float[] targetFreqs = { 80f, 250f, 600f, 1500f, 3500f };
-                // 补偿倍率：频率越高，现实中能量越小，需要强制放大视觉效果
-                float[] weights = { 1.0f, 1.8f, 2.8f, 4.5f, 6.5f };
-
-                for (int i = 0; i < 5; i++)
-                {
-                    float freq = Math.Min(targetFreqs[i], actualSampleRate / 2.2f);
-                    float k = MathF.Round(freq * 256f / actualSampleRate);
-                    float coeff = 2f * MathF.Cos(2f * MathF.PI * k / 256f);
-                    // 存入特定的权重
-                    _state[i] = (coeff, 0, 0, 0, weights[i]);
-                }
-
-                _capture.DataAvailable += OnAudioData;
-                _capture.RecordingStopped += (s, e) => {
-                    // 设备被拔出时清零
-                    Array.Clear(_backBars, 0, 5);
-                    Interlocked.Exchange(ref _frontBars, _backBars);
-                };
-                _capture.StartRecording();
+                _enumerator = enumerator;
+                _endpointVolume = volume;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
-                Logger.Error("音频捕获初始化失败，可能是无权限或无音频设备", ex);
-                // 无权限或无音频设备时静默，全 0 柱子输出
+                Logger.Warn($"音频事件订阅失败，将无法感知设备变化: {ex.Message}");
             }
+        }
+
+        /// <summary>找到本进程在默认输出设备上的捕获会话，订阅其断开事件（独占抢占时会通知）。</summary>
+        private void RegisterSessionEvents()
+        {
+            try
+            {
+                var enumerator = _enumerator;
+                if (enumerator == null) return;
+
+                var device = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                var sessions = device.AudioSessionManager.Sessions;
+                uint pid = (uint)Environment.ProcessId;
+
+                for (int i = 0; i < sessions.Count; i++)
+                {
+                    var session = sessions[i];
+                    if (session.GetProcessID != pid) continue;
+
+                    session.RegisterEventClient(_sessionEvents);
+                    _sessionControl = session;
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug($"音频会话事件订阅失败: {ex.Message}");
+            }
+        }
+
+        private void OnSessionDisconnected(AudioSessionDisconnectReason reason)
+        {
+            // 独占抢占 / 格式变更 / 设备移除 等都会走到这里，说明当前捕获已经作废
+            Logger.Info($"音频会话已断开({reason})，等待设备释放后恢复");
+            ClearBars();
+            RequestCheck();
+        }
+
+        private sealed class NotificationClient(AudioAnalyzer owner) : IMMNotificationClient
+        {
+            public void OnDeviceStateChanged(string deviceId, DeviceState newState) => owner.EnsureCaptureAlive();
+            public void OnDeviceAdded(string deviceId) => owner.EnsureCaptureAlive();
+            public void OnDeviceRemoved(string deviceId) => owner.EnsureCaptureAlive();
+            public void OnPropertyValueChanged(string deviceId, PropertyKey key) => owner.EnsureCaptureAlive();
+            public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
+            {
+                if (flow == DataFlow.Render) owner.EnsureCaptureAlive();
+            }
+        }
+
+        private sealed class SessionEventsHandler(AudioAnalyzer owner) : IAudioSessionEventsHandler
+        {
+            public void OnSessionDisconnected(AudioSessionDisconnectReason disconnectReason) => owner.OnSessionDisconnected(disconnectReason);
+            public void OnStateChanged(AudioSessionState state) { }
+            public void OnVolumeChanged(float volume, bool isMuted) { }
+            public void OnDisplayNameChanged(string displayName) { }
+            public void OnIconPathChanged(string iconPath) { }
+            public void OnChannelVolumeChanged(uint channelCount, IntPtr newVolumes, uint channelIndex) { }
+            public void OnGroupingParamChanged(ref Guid groupingId) { }
+        }
+
+        // ===================== 频谱计算 =====================
+
+        private void ConfigureBands(WaveFormat format)
+        {
+            _channels = format.Channels;
+
+            // 核心优化：极速降采样 (Decimation)。比如 48000Hz -> 取每 6 个样本中的 1 个 = 8000Hz
+            _decimationFactor = Math.Max(1, format.SampleRate / TargetSampleRate);
+            int actualSampleRate = format.SampleRate / _decimationFactor;
+
+            // 重新挑选 5 个最具代表性的律动频段，并进行巨大的高频能量补偿
+            // 1. 底鼓 (80Hz) 2. 军鼓/下盘 (250Hz) 3. 人声 (600Hz) 4. 乐器高频 (1500Hz) 5. 极高频/镲片 (3500Hz)
+            float[] targetFreqs = { 80f, 250f, 600f, 1500f, 3500f };
+            // 补偿倍率：频率越高，现实中能量越小，需要强制放大视觉效果
+            float[] weights = { 1.0f, 1.8f, 2.8f, 4.5f, 6.5f };
+
+            for (int i = 0; i < 5; i++)
+            {
+                float freq = Math.Min(targetFreqs[i], actualSampleRate / 2.2f);
+                float k = MathF.Round(freq * 256f / actualSampleRate);
+                float coeff = 2f * MathF.Cos(2f * MathF.PI * k / 256f);
+                // 存入特定的权重
+                _state[i] = (coeff, 0, 0, 0, weights[i]);
+            }
+
+            _sampleCount = 0;
+            _currentPeak = 0.1f;
         }
 
         private void OnAudioData(object? sender, WaveInEventArgs e)
         {
+            Volatile.Write(ref _lastDataTicks, DateTime.UtcNow.Ticks);
+
             // WaveBuffer 提供 Zero-Copy 的方式直接把 byte[] 强转读作 float[]
             var buffer = new WaveBuffer(e.Buffer);
             int floatCount = e.BytesRecorded / 4;
@@ -133,6 +445,14 @@ namespace NotchPeninsula
                     _backBars = oldFront;
                 }
             }
+        }
+
+        private void ClearBars()
+        {
+            Array.Clear(_backBars, 0, 5);
+            var oldFront = Interlocked.Exchange(ref _frontBars, _backBars);
+            Array.Clear(oldFront, 0, 5);
+            _backBars = oldFront;
         }
 
         public float[] GetBars() => _frontBars;

--- a/Just-Solo-LyricServer.md
+++ b/Just-Solo-LyricServer.md
@@ -1,0 +1,822 @@
+# Just Solo LyricServer 协议 v1.2.0
+
+## 简介
+
+Just Solo LyricServer 协议 是 Just Solo 内置的实时歌词推送协议，基于 WebSocket（`ws://127.0.0.1:47290`），将播放器中当前歌曲的歌词时间轴、播放进度和实时音频频谱以 JSON 单向推送给本地客户端。适用于桌面歌词悬浮窗、频谱可视化等任意需实时同步播放数据的场景。
+
+---
+
+## 目录
+
+1. [概述](#1-概述)
+2. [连接规范](#2-连接规范)
+3. [歌词数据源](#3-歌词数据源)
+4. [消息类型](#4-消息类型)
+   - [4.1 `init` — 歌词时间轴](#41-init--歌词时间轴)
+   - [4.2 `progress` — 播放进度](#42-progress--播放进度)
+   - [4.3 `playback` — 播放状态变更](#43-playback--播放状态变更)
+   - [4.4 `spectrum` — 音频频谱](#44-spectrum--音频频谱)
+5. [客户端状态机](#5-客户端状态机)
+6. [客户端实现指南](#6-客户端实现指南)
+   - [6.1 歌词行定位（二分查找）](#61-歌词行定位二分查找)
+   - [6.2 平滑插值](#62-平滑插值)
+   - [6.3 滚动行为](#63-滚动行为)
+   - [6.4 重连策略](#64-重连策略)
+   - [6.5 频谱渲染（协议v1.2.0+）](#65-频谱渲染协议v120)
+7. [多语言客户端示例](#7-多语言客户端示例)
+   - [7.1 JavaScript（浏览器）](#71-javascript浏览器)
+   - [7.2 Python](#72-python)
+   - [7.3 C#](#73-c)
+8. [故障排查](#8-故障排查)
+9. [版本历史](#9-版本历史)
+
+---
+
+## 1. 概述
+
+Just Solo LyricServer 是 Just Solo 音乐播放器内置的 **单向 WebSocket 歌词推送服务**。它在本地回环地址上监听，将当前播放歌曲的歌词时间轴、播放进度和实时音频频谱推送给连接的客户端。
+
+```
+┌──────────────────┐      WebSocket JSON       ┌─────────────────┐
+│   Just Solo      │ ◄══════════════════════►  │  第三方客户端    │
+│   (播放器)        │     ws://127.0.0.1:47290   │  (桌面歌词等)    │
+│                  │     单向推送 (→ only)       │                 │
+│  ┌────────────┐  │                           └─────────────────┘
+│  │MusicManager│──┼── signals ──► LyricServer
+│  └────────────┘  │
+└──────────────────┘
+```
+
+**核心设计原则：**
+
+| 原则 | 说明 |
+|------|------|
+| 单向推送 | 客户端只接收消息，不发送任何指令；所有播放控制通过 Just Solo 本体 |
+| 本地环回 | 仅监听 `127.0.0.1`，不暴露到局域网或公网 |
+| 最小开销 | `progress` / `spectrum` 每帧约 40–100 字节 JSON；无客户端时自动停推 |
+| 即连即用 | 连接后立即补推当前完整状态，零握手 |
+| 无状态服务端 | 不维护客户端会话，任意数量客户端并发连接 |
+| 客户端名称（协议v1.1.0+） | 客户端可在连接后发送可选的 `hello` 消息声明名称；旧客户端不发送也完全兼容 |
+| 实时频谱（协议v1.2.0+） | 播放时以 100ms 周期推送 `spectrum` 消息（12 频段电平 0~1）；暂停 / 无客户端自动停推 |
+
+---
+
+## 2. 连接规范
+
+### 2.1 连接参数
+
+```
+ws://127.0.0.1:47290
+```
+
+| 参数 | 值 |
+|------|-----|
+| 协议 | WebSocket（RFC 6455），非加密 `ws://` |
+| 地址 | `127.0.0.1`（仅 IPv4 本地环回） |
+| 端口 | `47290` |
+| 数据格式 | UTF-8 编码的 JSON 文本帧（opcode 0x1） |
+| 最大客户端数 | 无硬限制（由操作系统文件描述符决定） |
+| 子协议 | 不要求（`Sec-WebSocket-Protocol` 头部忽略） |
+
+### 2.2 握手
+
+标准 WebSocket 握手，无需额外头部。服务端不验证 `Origin`。
+
+**客户端请求示例：**
+```
+GET / HTTP/1.1
+Host: 127.0.0.1:47290
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+Sec-WebSocket-Version: 13
+```
+
+### 2.3 客户端名称声明（协议v1.1.0+，可选）
+
+客户端在 WebSocket 连接建立后，可发送一条 `hello` 消息声明自己的名称。Just Solo 收到后会弹出通知提示用户。
+
+```json
+{"type":"hello","client":"我的桌面歌词"}
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `type` | `string` | 是 | 固定 `"hello"` |
+| `client` | `string` | 是 | 客户端名称，任意 UTF-8 文本 |
+
+**向下兼容：** 旧客户端不发送 `hello` 消息也能正常使用所有推送功能。Just Solo 会在连接 500ms 后按"未知客户端"通知用户。
+
+### 2.4 Ping / Pong
+
+服务端 **不主动发送** Ping 帧，也不要求客户端发 Pong。断线检测依赖 TCP 层面的 `disconnected` 信号、操作系统 TCP keep-alive（默认 2 小时）及客户端自身的重连逻辑。
+
+### 2.5 端口冲突
+
+如果 `47290` 端口已被占用，`LyricServer::start()` 返回 `false`，Just Solo 仍正常运行但 `lyricServer.running === false`。设置页"关于"中将显示「未启用」。
+
+---
+
+## 3. 歌词数据源
+
+LyricServer 推送的歌词来自 Just Solo 的 `MusicManager`，后者通过以下优先级加载歌词：
+
+### 3.1 加载优先级
+
+| 优先级 | 来源 | 说明 |
+|--------|------|------|
+| 1 | 外部 `.lrc` 文件 | 与音频文件同目录、同名的 `.lrc`（大小写不敏感） |
+| 2 | 嵌入式歌词 | 音频文件内嵌的 `LYRICS` 标签（ID3v2 USLT / VorbisComment LYRICS），异步读取 |
+| 3 | 纯文本降级 | 嵌入式歌词若无时间标签，按行拆分，依歌曲总时长均匀分配时间戳 |
+
+### 3.2 LRC 格式解析规则
+
+服务端按以下规则解析标准 LRC 文件（UTF-8 编码，忽略 BOM）：
+
+**时间标签正则：**
+```
+\[(\d{1,3}):(\d{1,3})(?:\.(\d{1,3}))?\]
+```
+支持 `[mm:ss]` 和 `[mm:ss.xx]` 和 `[mm:ss.xxx]` 三种精度。
+
+**元数据标签跳过：**
+```
+[ti:标题] [ar:艺术家] [al:专辑] [by:作者] [offset:偏移] [length:长度]
+```
+这些行不产生歌词条目。
+
+**翻译识别：**
+- 同一时间戳出现多行时，自动检测第二行是否为翻译（拉丁字母占主导 → 翻译；否则合并为一行，`\n` 分隔）。
+- 翻译文本写入 `translation` 字段，不占用独立歌词行。
+
+**多时间标签：**
+```lrc
+[00:15.00][00:30.00]重复的副歌
+```
+展开为两条独立条目。
+
+**示例 LRC 文件：**
+```lrc
+[ti:光辉岁月]
+[ar:Beyond]
+[00:00.00]
+[00:15.50]钟声响起归家的讯号
+[00:15.50]The bell rings for home
+[00:22.30]在他生命里
+[00:22.30]In his life
+[00:30.00]仿佛带点唏嘘
+[00:30.00]As if with some sigh
+```
+
+解析结果（`init` 消息的 `lyrics` 数组）：
+```json
+[
+  { "time": 15500, "text": "钟声响起归家的讯号", "translation": "The bell rings for home" },
+  { "time": 22300, "text": "在他生命里",           "translation": "In his life" },
+  { "time": 30000, "text": "仿佛带点唏嘘",         "translation": "As if with some sigh" }
+]
+```
+
+### 3.3 歌词偏移
+
+Just Solo 设置页提供「歌词预读偏移」滑块（范围 50–350ms，默认 130ms）。该偏移在 LyricServer 内部**已生效**——`init` 的 `time` 字段是原始 LRC 时间戳，客户端收到的 `progress.position` 是播放器实际位置；Just Solo 自身的歌词高亮用 `musicManager.lyricOffset` 做内部补偿，**客户端如需与 Just Solo 完全同步高亮，应在前端自行实现相同的偏移逻辑**。
+
+> 偏移默认值 130ms 来自经验值——歌词显示稍早于人耳感知，阅读更舒适。
+
+---
+
+## 4. 消息类型
+
+### 消息通用格式
+
+每条消息是一个单行 JSON 对象（Compact，无缩进），顶层必含 `type` 字段。
+
+```json
+{"type":"...", ...}
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `type` | `string` | 消息类型标识：`init` / `progress` / `playback` / `spectrum` |
+
+---
+
+### 4.1 `init` — 歌词时间轴
+
+#### 触发条件
+
+| 场景 | 行为 |
+|------|------|
+| 切歌（播放下一首、双击曲目等） | 当前歌词变为新歌 → 广播 `init` |
+| 歌词异步加载完成（嵌入式） | `currentLyricsChanged` 信号触发 → 广播 `init` |
+| 新客户端连接 | 立即单独推送当前歌词（不广播） |
+
+#### 消息结构
+
+```json
+{
+  "type": "init",
+  "lyrics": [
+    { "time": 0,     "text": "♪ 纯音乐前奏" },
+    { "time": 12450, "text": "第一行歌词" },
+    { "time": 18200, "text": "第二行歌词", "translation": "Line two translation" }
+  ]
+}
+```
+
+#### 字段规范
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `type` | `string` | 是 | 固定 `"init"` |
+| `lyrics` | `array<object>` | 是 | 歌词行数组，按 `time` 严格升序 |
+| `lyrics[].time` | `int` | 是 | 该行起始时间戳，单位毫秒，非负整数 |
+| `lyrics[].text` | `string` | 是 | 歌词文本，可能为空字符串（纯间奏标记） |
+| `lyrics[].translation` | `string` | 否 | 翻译文本，仅当 LRC 文件含翻译时存在 |
+
+#### 边界情况
+
+| 场景 | `lyrics` 内容 |
+|------|---------------|
+| 歌曲有完整 LRC 歌词 | 时间戳 + 文本 + 翻译（如有） |
+| 歌曲只有嵌入式文本（无时间戳） | 按歌曲时长均匀分配时间戳 |
+| 纯音乐（无任何歌词） | `[]`（空数组） |
+| 歌词正在异步加载（嵌入式） | 先推 `[]`，加载完成后推完整数组 |
+
+#### `translation` 字段
+
+仅当 LRC 文件中同一时间戳存在第二行，且被判定为翻译时，该字段才出现。客户端可据此实现双语歌词显示。
+
+```json
+{
+  "type": "init",
+  "lyrics": [
+    { "time": 1200,  "text": "あの日の景色が",    "translation": "那天的景色" },
+    { "time": 3500,  "text": "今も胸に焼き付いて", "translation": "至今深印心中" }
+  ]
+}
+```
+
+---
+
+### 4.2 `progress` — 播放进度
+
+#### 触发条件
+
+| 场景 | 行为 |
+|------|------|
+| 播放中 | 每 400ms（±5ms 系统调度误差）广播一帧 |
+| 暂停 | 立即停止推送 |
+| 停止 / 切歌 | 停止推送 |
+| 恢复播放 | 立即推一帧 + 恢复 400ms 周期 |
+| 无客户端连接 | 定时器自动停转 |
+
+#### 消息结构
+
+```json
+{
+  "type": "progress",
+  "position": 15680
+}
+```
+
+#### 字段规范
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `type` | `string` | 是 | 固定 `"progress"` |
+| `position` | `int` | 是 | 当前播放位置，单位毫秒，自曲目开头起算 |
+
+#### 精度说明
+
+- 时间来源：Qt `QMediaPlayer::position()`，精度取决于后端（Windows Media Foundation 通常 ±10ms）
+- 推送间隔：400ms（不是 position 本身的精度窗口）
+- 首次恢复播放时，`progress` 在 `playback` 消息**之后**立即发出，不等 400ms 定时器
+- `progress` 与 `spectrum`（见 [4.4](#44-spectrum--音频频谱)）各自独立推送、互不影响
+
+---
+
+### 4.3 `playback` — 播放状态变更
+
+#### 触发条件
+
+| 场景 | 行为 |
+|------|------|
+| 用户点击播放 / 暂停 / 快捷键 | 广播 `playback` |
+| 曲目自然结束 → 下一首 | 先 `init`（新歌词），`playback` 状态保持 `"playing"` |
+| 新客户端连接 | 立即单独推送当前状态 |
+
+#### 消息结构
+
+```json
+{
+  "type": "playback",
+  "status": "playing"
+}
+```
+
+#### 字段规范
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `type` | `string` | 是 | 固定 `"playback"` |
+| `status` | `string` | 是 | `"playing"` 或 `"paused"` |
+
+> 协议不包含 `"stopped"` 状态——Just Solo 不区分暂停与停止（停止 = 暂停 + 进度归零 + 从头播放）。
+
+---
+
+### 4.4 `spectrum` — 音频频谱（协议v1.2.0+）
+
+#### 触发条件
+
+| 场景 | 行为 |
+|------|------|
+| 播放中 | 每 100ms（±5ms 系统调度误差）广播一帧 |
+| 暂停 / 停止 / 切歌 | 立即停止推送；客户端应在收到 `playback("paused")` 时清空频谱显示 |
+| 恢复播放 | 立即推一帧 + 恢复 100ms 周期 |
+| 无客户端连接 | 定时器自动停转 |
+
+#### 消息结构
+
+```json
+{
+  "type": "spectrum",
+  "bands": [0.12, 0.35, 0.58, 0.71, 0.66, 0.49, 0.38, 0.29, 0.21, 0.15, 0.12, 0.08]
+}
+```
+
+#### 字段规范
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `type` | `string` | 是 | 固定 `"spectrum"` |
+| `bands` | `array<number>` | 是 | 12 个频段电平（0.0 ~ 1.0），从低频到高频排列；暂无数据时为空数组 `[]` |
+
+#### 频段说明
+
+- 数据来源：Just Solo `AudioEngine` 对实际输出帧做 FFT（1024 点 Hann 窗），按对数刻度聚合为 12 个频段（约 40Hz ~ 16kHz），各频段取峰值。
+- 取值范围：0.0 ~ 1.0（满幅正弦 ≈ 1.0），保留 3 位小数。
+- 数量固定：始终 12 个元素（v1.2.0 起固定），客户端可直接按 12 柱渲染。
+- 与播放进度解耦：`spectrum` 与 `progress` 各自独立推送，客户端可分开使用。
+
+#### 边界情况
+
+| 场景 | `bands` 内容 |
+|------|---------------|
+| 播放中（有真实频谱数据） | 12 个 0.0 ~ 1.0 的数值 |
+| 刚恢复播放（音频缓冲未填满） | 可能为空数组 `[]` |
+| 暂停 / 停止 | 不再推送（客户端配合 `playback("paused")` 清空） |
+
+---
+
+## 5. 客户端状态机
+
+```
+                     ┌──────────┐
+           ┌────────│  DISCONNECTED  │
+           │        └──────┬─────────┘
+           │               │ connect()
+           │        ┌──────▼─────────┐
+           │  ┌─────│  CONNECTING    │──── 连接失败 ──► DISCONNECTED
+           │  │     └──────┬─────────┘
+           │  │            │ onopen
+           │  │     ┌──────▼─────────┐
+           │  │     │   CONNECTED    │
+           │  │     └──┬──────┬──────┘
+           │  │        │      │
+           │  │   ← init    ← playback     （立即收到）
+           │  │   ← progress / spectrum（若播放中）
+           │  │        │      │
+           │  │   ┌────▼──────▼──────┐
+           │  │   │    RUNNING       │◄── 每 400ms: progress / 每 100ms: spectrum
+           │  │   └────┬──────┬──────┘◄── 事件驱动: init / playback
+           │  │        │      │
+           │  │   切歌: init  暂停: playback("paused")
+           │  │   恢复: playback("playing") + progress + spectrum
+           │  │        │      │
+           │  │   ┌────▼──────▼──────┐
+           │  └──►│   DISCONNECTED   │  （ws 断开 / 错误）
+           │      └─────────────────┘
+           │               │
+           └── 重连（退避） ──┘
+```
+
+**状态转换触发条件：**
+
+| 转换 | 触发 |
+|------|------|
+| DISCONNECTED → CONNECTING | 客户端主动 `new WebSocket(url)` |
+| CONNECTING → CONNECTED | WebSocket `onopen` |
+| CONNECTING → DISCONNECTED | 连接超时或 `onerror` |
+| CONNECTED → RUNNING | 收到至少一条消息后 |
+| RUNNING → DISCONNECTED | `onclose` / `onerror` |
+
+---
+
+## 6. 客户端实现指南
+
+### 6.1 歌词行定位（二分查找）
+
+服务端每 400ms 推送 `progress`。客户端需要在 `lyrics` 数组中定位当前位置对应的歌词行。
+
+**算法：**二分查找最后一个 `time <= position` 的索引。
+
+```
+lyrics: [0, 5000, 10000, 15000, 20000]
+position: 12500
+
+lo=0 hi=4 mid=2: lyrics[2].time=10000 <= 12500 ✓ → ans=2, lo=3
+lo=3 hi=4 mid=3: lyrics[3].time=15000 > 12500  ✗ → hi=2
+lo > hi → 返回 ans=2（"10000: 第三行"）
+```
+
+**时间复杂度：** O(log n)，500 行的歌词约 9 次比较。
+
+**伪代码：**
+```
+function findCurrentLine(lyrics, position):
+    lo = 0, hi = lyrics.length - 1, ans = -1
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if lyrics[mid].time <= position:
+            ans = mid; lo = mid + 1
+        else:
+            hi = mid - 1
+    return ans
+```
+
+> 若 `ans === -1`：歌曲尚未到达第一行歌词（前奏），高亮第一行或不亮均可。
+
+### 6.2 平滑插值
+
+`progress` 推送间隔 400ms。若 UI 需要更高帧率（如 60fps 的平滑滚动），客户端可对 `position` 做线性插值：
+
+```
+estimatedPosition = lastPosition + (Date.now() - lastTimestamp)
+```
+
+- `lastPosition`：最近一次 `progress` 的 `position` 值
+- `lastTimestamp`：收到该 `progress` 时的 `performance.now()` 或 `Date.now()`
+- 收到新 `progress` 时重置；`playback("paused")` 时冻结
+
+### 6.3 滚动行为
+
+歌词显示逐行滚动的推荐策略：
+
+| 策略 | 适用场景 | 说明 |
+|------|----------|------|
+| 即时跳转 | 移动端 / 性能受限 | 当前行改变时 `scrollIntoView({ behavior: "smooth" })` |
+| 匀速滚动 | 桌面端 / 高质量体验 | 用 `requestAnimationFrame` 驱动，基于 `position` 线性推进 |
+| 居中锁定 | karaoke 风格 | 当前行始终固定在视口中央 |
+
+### 6.4 重连策略
+
+**推荐指数退避：**
+
+```
+初始延迟    1 秒
+最大延迟   30 秒
+退避因子   2×
+```
+
+```
+连接断开 → 1s → 失败 → 2s → 失败 → 4s → ... → 30s → 30s...
+连接成功 → 重置延迟为 1s
+```
+
+服务端不提供重连服务，重连完全由客户端负责。
+
+### 6.5 频谱渲染（协议v1.2.0+）
+
+`spectrum` 推送周期 100ms（10fps）。客户端渲染频谱柱的推荐策略：
+
+| 场景 | 处理 |
+|------|------|
+| 收到 `spectrum` 且 `bands` 非空 | 将 12 个 0.0~1.0 数值直接映射为柱高（0.0=0%、1.0=100%） |
+| 收到 `spectrum` 且 `bands` 为空 `[]` | 保持当前画面或短暂归零（刚恢复播放时缓冲未填满） |
+| 收到 `playback("paused")` | 清空频谱（柱高归零），不依赖最后一帧残留 |
+| 渲染帧率 | 频谱动画建议用 `requestAnimationFrame` 在 10fps 数据间做插值/衰减，避免柱高跳变 |
+
+> 若客户端仅需要歌词，忽略 `spectrum` 消息即可，不影响其他功能。
+
+---
+
+## 7. 多语言客户端示例
+
+### 7.1 JavaScript（浏览器）
+
+```javascript
+class LyricClient {
+  constructor(url = 'ws://127.0.0.1:47290') {
+    this.url = url;
+    this.lyrics = [];
+    this.position = 0;
+    this.spectrum = [];
+    this.isPlaying = false;
+    this.reconnectDelay = 1000;
+    this.connect();
+  }
+
+  connect() {
+    this.ws = new WebSocket(this.url);
+    this.ws.onopen = () => {
+      this.reconnectDelay = 1000;
+      this.onStatusChange('connected');
+      // v1.1.0+: 声明客户端名称（可选，向下兼容）
+      this.ws.send(JSON.stringify({ type: 'hello', client: '我的桌面歌词' }));
+    };
+    this.ws.onmessage = (ev) => {
+      const msg = JSON.parse(ev.data);
+      switch (msg.type) {
+        case 'init':
+          this.lyrics = msg.lyrics || [];
+          this.onLyricsChanged(this.lyrics);
+          break;
+        case 'progress':
+          this.position = msg.position;
+          this.onProgress(this.position);
+          break;
+        case 'playback':
+          this.isPlaying = (msg.status === 'playing');
+          this.onPlaybackChange(this.isPlaying);
+          break;
+        case 'spectrum':   // v1.2.0+
+          this.spectrum = msg.bands || [];
+          this.onSpectrumChange(this.spectrum);
+          break;
+      }
+    };
+    this.ws.onclose = () => {
+      this.onStatusChange('disconnected');
+      setTimeout(() => this.connect(), this.reconnectDelay);
+      this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
+    };
+    this.ws.onerror = () => this.ws.close();
+  }
+
+  // 二分查找当前歌词行
+  getCurrentLineIndex() {
+    let lo = 0, hi = this.lyrics.length - 1, ans = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (this.lyrics[mid].time <= this.position)
+        { ans = mid; lo = mid + 1; }
+      else
+        hi = mid - 1;
+    }
+    return ans;
+  }
+
+  // ---- 以下为回调，由子类或外部覆写 ----
+  onLyricsChanged(lyrics) {}
+  onProgress(position) {}
+  onPlaybackChange(playing) {}
+  onSpectrumChange(bands) {}   // v1.2.0+：12 个 0~1 频段电平
+  onStatusChange(status) {}
+}
+```
+
+### 7.2 Python
+
+```python
+import asyncio
+import json
+import websockets
+
+class LyricClient:
+    def __init__(self, url="ws://127.0.0.1:47290"):
+        self.url = url
+        self.lyrics = []
+        self.position = 0
+        self.spectrum = []
+        self.is_playing = False
+        self._reconnect_delay = 1
+
+    async def connect(self):
+        while True:
+            try:
+                async with websockets.connect(self.url) as ws:
+                    self._reconnect_delay = 1
+                    self.on_status_change("connected")
+                    # v1.1.0+: 声明客户端名称（可选，向下兼容）
+                    await ws.send(json.dumps({"type": "hello", "client": "我的桌面歌词"}))
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        await self._handle(msg)
+            except (OSError, websockets.ConnectionClosed):
+                self.on_status_change("disconnected")
+                await asyncio.sleep(self._reconnect_delay)
+                self._reconnect_delay = min(self._reconnect_delay * 2, 30)
+
+    async def _handle(self, msg):
+        t = msg["type"]
+        if t == "init":
+            self.lyrics = msg.get("lyrics", [])
+            await self.on_lyrics_changed(self.lyrics)
+        elif t == "progress":
+            self.position = msg["position"]
+            await self.on_progress(self.position)
+        elif t == "playback":
+            self.is_playing = (msg["status"] == "playing")
+            await self.on_playback_change(self.is_playing)
+        elif t == "spectrum":  # v1.2.0+
+            self.spectrum = msg.get("bands", [])
+            await self.on_spectrum_change(self.spectrum)
+
+    def current_line_index(self):
+        lo, hi, ans = 0, len(self.lyrics) - 1, -1
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            if self.lyrics[mid]["time"] <= self.position:
+                ans, lo = mid, mid + 1
+            else:
+                hi = mid - 1
+        return ans
+
+    async def on_lyrics_changed(self, lyrics): pass
+    async def on_progress(self, position): pass
+    async def on_playback_change(self, playing): pass
+    async def on_spectrum_change(self, bands): pass
+    def on_status_change(self, status): pass
+
+# 使用
+if __name__ == "__main__":
+    client = LyricClient()
+    asyncio.run(client.connect())
+```
+
+> 依赖：`pip install websockets`
+
+### 7.3 C#
+
+```csharp
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class LyricClient : IDisposable
+{
+    private readonly string _url;
+    private ClientWebSocket _ws;
+    private CancellationTokenSource _cts;
+
+    public LyricEntry[] Lyrics { get; private set; } = Array.Empty<LyricEntry>();
+    public int Position { get; private set; }
+    public double[] Spectrum { get; private set; } = Array.Empty<double>();
+    public bool IsPlaying { get; private set; }
+    public bool Connected => _ws?.State == WebSocketState.Open;
+
+    public event Action<LyricEntry[]> OnLyricsChanged;
+    public event Action<int> OnProgress;
+    public event Action<bool> OnPlaybackChanged;
+    public event Action<double[]> OnSpectrumChanged;
+    public event Action<bool> OnConnectionChanged;
+
+    public LyricClient(string url = "ws://127.0.0.1:47290")
+    {
+        _url = url;
+    }
+
+    public async Task ConnectAsync()
+    {
+        var delay = 1000;
+        while (!_cts?.IsCancellationRequested ?? true)
+        {
+            try
+            {
+                _cts = new CancellationTokenSource();
+                _ws = new ClientWebSocket();
+                await _ws.ConnectAsync(new Uri(_url), _cts.Token);
+                OnConnectionChanged?.Invoke(true);
+                delay = 1000;
+
+                // v1.1.0+: 声明客户端名称（可选，向下兼容）
+                var hello = Encoding.UTF8.GetBytes(
+                    JsonSerializer.Serialize(new { type = "hello", client = "我的桌面歌词" }));
+                await _ws.SendAsync(hello, WebSocketMessageType.Text, true, _cts.Token);
+
+                var buffer = new byte[4096];
+                var sb = new StringBuilder();
+
+                while (_ws.State == WebSocketState.Open)
+                {
+                    var result = await _ws.ReceiveAsync(buffer, _cts.Token);
+                    sb.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+                    if (result.EndOfMessage)
+                    {
+                        HandleMessage(sb.ToString());
+                        sb.Clear();
+                    }
+                }
+            }
+            catch
+            {
+                OnConnectionChanged?.Invoke(false);
+                await Task.Delay(delay);
+                delay = Math.Min(delay * 2, 30000);
+            }
+        }
+    }
+
+    private void HandleMessage(string raw)
+    {
+        using var doc = JsonDocument.Parse(raw);
+        var type = doc.RootElement.GetProperty("type").GetString();
+        switch (type)
+        {
+            case "init":
+                Lyrics = JsonSerializer.Deserialize<LyricEntry[]>(
+                    doc.RootElement.GetProperty("lyrics").GetRawText());
+                OnLyricsChanged?.Invoke(Lyrics);
+                break;
+            case "progress":
+                Position = doc.RootElement.GetProperty("position").GetInt32();
+                OnProgress?.Invoke(Position);
+                break;
+            case "playback":
+                IsPlaying = doc.RootElement.GetProperty("status").GetString() == "playing";
+                OnPlaybackChanged?.Invoke(IsPlaying);
+                break;
+            case "spectrum":  // v1.2.0+
+                Spectrum = JsonSerializer.Deserialize<double[]>(
+                    doc.RootElement.GetProperty("bands").GetRawText());
+                OnSpectrumChanged?.Invoke(Spectrum);
+                break;
+        }
+    }
+
+    public int CurrentLineIndex()
+    {
+        int lo = 0, hi = Lyrics.Length - 1, ans = -1;
+        while (lo <= hi)
+        {
+            int mid = (lo + hi) / 2;
+            if (Lyrics[mid].Time <= Position) { ans = mid; lo = mid + 1; }
+            else hi = mid - 1;
+        }
+        return ans;
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _ws?.Dispose();
+    }
+}
+
+public class LyricEntry
+{
+    public int Time { get; set; }
+    public string Text { get; set; }
+    public string Translation { get; set; }
+}
+```
+
+> 依赖：`System.Net.WebSockets`（.NET Framework 4.5+ / .NET Core 2.0+）
+
+---
+
+## 8. 故障排查
+
+### 8.1 连接失败
+
+| 症状 | 可能原因 | 解决 |
+|------|----------|------|
+| `WebSocket connection refused` | Just Solo 未运行，或 LyricServer 启动失败 | 检查任务管理器是否有 `JustSolo.exe` 进程；查看 Just Solo 设置 → 关于 → LyricServer 状态 |
+| `WebSocket connection timeout` | 防火墙拦截本地回环 | Windows 防火墙通常不拦截 127.0.0.1；检查是否有第三方安全软件 |
+| 连接成功但无消息 | 播放器未播放任何歌曲 | 播放一首歌后应收到 `init` |
+
+### 8.2 端口占用
+
+```powershell
+# 查看 47290 端口占用
+netstat -ano | findstr 47290
+```
+
+若被其他进程占用，LyricServer 自动降级（`running = false`），Just Solo 正常运行。如需更改端口，修改 `main.cpp` 中 `lyricServer->start(47290)` 的参数。
+
+### 8.3 歌词不更新
+
+| 症状 | 原因 |
+|------|------|
+| `init` 收到但 `lyrics` 为空 `[]` | 歌曲无 LRC 文件且无嵌入式歌词 |
+| 切歌后 `init` 不变 | 异步加载嵌入式歌词中，等待 `currentLyricsChanged` 二次触发 |
+| 进度超过最后一行后高亮消失 | 正常——歌曲结束后无对应行；客户端应保持最后一行高亮 |
+
+---
+
+## 9. 版本历史
+
+> 除特殊说明，所有版本向下兼容。
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| v1.2.0 | 2026-08-14 | 新增 `spectrum` 消息：播放时以 100ms 周期推送 12 频段实时音频频谱（0.0~1.0，40Hz~16kHz 对数分布），用于解决独占音频时其他软件无法获取频谱的问题；`progress` 推送间隔按 v1.0.2 修订为 400ms；向下兼容旧客户端（未知消息类型忽略） |
+| v1.1.0 | 2026-08-05 | 新增可选 `hello` 消息：客户端可声明名称，Just Solo 弹窗提示第三方连接；向下兼容旧客户端 |
+| v1.0.2 | 2026-07-26 | 将`progress` 推送间隔从 300ms 变更为 400ms，修复进度更新过快问题 |
+| v1.0.1 | 2026-07-25 | 修复Just Solo内置的LyricServer问题：将`progress` 推送间隔从 200ms 更改为 300ms，修复进度更新过快问题 |
+| v1.0.0 | 2026-07-24 | 初始发布；`init`（lyrics 含 translation 字段）+ `progress`（200ms）+ `playback`（playing/paused） |

--- a/JustSoloLyricClient.cs
+++ b/JustSoloLyricClient.cs
@@ -1,0 +1,262 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+
+namespace NotchPeninsula
+{
+    /// <summary>
+    /// Just Solo LyricServer（ws://127.0.0.1:47290）客户端。
+    /// 单向接收 init / progress / playback 推送，供本地歌词高亮使用。
+    /// 协议文档：Just-Solo-LyricServer.md
+    /// </summary>
+    internal sealed class JustSoloLyricClient
+    {
+        private const string ServerUrl = "ws://127.0.0.1:47290";
+        private const int InitialReconnectDelayMs = 1000;
+        private const int MaxReconnectDelayMs = 30000;
+        // Just Solo 自身高亮使用的默认歌词预读偏移（client 需自行补偿才能与其同步）
+        private const float DefaultLyricPreReadSeconds = 0.13f;
+
+        private readonly record struct LyricLine(int Time, string Text, string Translation);
+
+        private readonly object _lock = new();
+        private LyricLine[] _lyrics = Array.Empty<LyricLine>();
+        private int _position;
+        private DateTime _positionStamp = DateTime.UtcNow;
+        private bool _isPlaying;
+
+        private volatile bool _running;   // 是否期望保持连接
+        private volatile bool _connected; // 当前是否已连接
+        private CancellationTokenSource? _cts;
+        private Task? _loopTask;
+
+        public bool IsRunning => _running;
+        public bool IsConnected => _connected;
+
+        /// <summary>开始连接（幂等）。</summary>
+        public void Start()
+        {
+            if (_running) return;
+            _running = true;
+            ResetState();
+
+            var cts = new CancellationTokenSource();
+            _cts = cts;
+            _loopTask = Task.Run(() => ConnectLoopAsync(cts.Token));
+        }
+
+        /// <summary>停止连接并清空状态。</summary>
+        public void Stop()
+        {
+            if (!_running) return;
+            _running = false;
+
+            var cts = _cts;
+            _cts = null;
+            var task = _loopTask;
+            _loopTask = null;
+
+            try { cts?.Cancel(); } catch { }
+
+            if (task != null) _ = task.ContinueWith(_ => cts?.Dispose(), TaskScheduler.Default);
+            else cts?.Dispose();
+
+            _connected = false;
+            ResetState();
+        }
+
+        /// <summary>
+        /// 读取当前应显示的歌词行。返回 false 表示 LyricServer 不可用，调用方应回退到其他歌词来源。
+        /// 已连接但无歌词（纯音乐）时返回 true 且 text 为空。
+        /// </summary>
+        public bool TryGetCurrentLyric(float userOffsetSeconds, out string text, out float progress)
+        {
+            text = "";
+            progress = 0f;
+
+            LyricLine[] lyrics;
+            int position;
+            bool playing;
+            DateTime stamp;
+            lock (_lock)
+            {
+                if (!_connected) return false;
+                lyrics = _lyrics;
+                position = _position;
+                playing = _isPlaying;
+                stamp = _positionStamp;
+            }
+
+            if (lyrics.Length == 0) return true;
+
+            // 进度每 400ms 才推送一次，用经过时间做线性插值保证高亮平滑
+            double elapsedMs = playing ? (DateTime.UtcNow - stamp).TotalMilliseconds : 0d;
+            double currentMs = position + elapsedMs + (DefaultLyricPreReadSeconds + userOffsetSeconds) * 1000.0;
+
+            // 二分查找最后一个 time <= currentMs 的歌词行
+            int lo = 0, hi = lyrics.Length - 1, ans = -1;
+            while (lo <= hi)
+            {
+                int mid = (lo + hi) >> 1;
+                if (lyrics[mid].Time <= currentMs) { ans = mid; lo = mid + 1; }
+                else hi = mid - 1;
+            }
+            if (ans < 0) return true;
+
+            var line = lyrics[ans];
+            text = string.IsNullOrEmpty(line.Text) ? line.Translation : line.Text;
+
+            double endMs = ans < lyrics.Length - 1 ? lyrics[ans + 1].Time : line.Time + 4000d;
+            double duration = endMs - line.Time;
+            if (duration > 0)
+                progress = (float)Math.Clamp((currentMs - line.Time) / duration, 0d, 1d);
+
+            return true;
+        }
+
+        private void ResetState()
+        {
+            lock (_lock)
+            {
+                _lyrics = Array.Empty<LyricLine>();
+                _position = 0;
+                _positionStamp = DateTime.UtcNow;
+                _isPlaying = false;
+            }
+        }
+
+        private async Task ConnectLoopAsync(CancellationToken token)
+        {
+            int delayMs = InitialReconnectDelayMs;
+
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    using var ws = new ClientWebSocket();
+                    await ws.ConnectAsync(new Uri(ServerUrl), token);
+
+                    _connected = true;
+                    delayMs = InitialReconnectDelayMs;
+                    Logger.Info("Just Solo LyricServer 已连接");
+
+                    await SendHelloAsync(ws, token);
+                    await ReceiveLoopAsync(ws, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Debug($"Just Solo LyricServer 连接失败: {ex.Message}");
+                }
+                finally
+                {
+                    _connected = false;
+                }
+
+                if (token.IsCancellationRequested) break;
+
+                // 指数退避：1s → 2s → … → 30s
+                try { await Task.Delay(delayMs, token); }
+                catch (OperationCanceledException) { break; }
+                delayMs = Math.Min(delayMs * 2, MaxReconnectDelayMs);
+            }
+
+            _connected = false;
+        }
+
+        private static async Task SendHelloAsync(ClientWebSocket ws, CancellationToken token)
+        {
+            var payload = Encoding.UTF8.GetBytes("{\"type\":\"hello\",\"client\":\"Notch Peninsula\"}");
+            await ws.SendAsync(payload, WebSocketMessageType.Text, true, token);
+        }
+
+        private async Task ReceiveLoopAsync(ClientWebSocket ws, CancellationToken token)
+        {
+            var buffer = new byte[4096];
+            var sb = new StringBuilder();
+
+            while (ws.State == WebSocketState.Open && !token.IsCancellationRequested)
+            {
+                var result = await ws.ReceiveAsync(buffer, token);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, token);
+                    break;
+                }
+
+                sb.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+                if (!result.EndOfMessage) continue;
+
+                HandleMessage(sb.ToString());
+                sb.Clear();
+            }
+        }
+
+        private void HandleMessage(string raw)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(raw);
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) return;
+                if (!root.TryGetProperty("type", out var typeEl)) return;
+
+                switch (typeEl.GetString())
+                {
+                    case "init":
+                        ApplyLyrics(root);
+                        break;
+
+                    case "progress":
+                        if (root.TryGetProperty("position", out var posEl) && posEl.TryGetInt32(out int pos))
+                        {
+                            lock (_lock)
+                            {
+                                _position = pos;
+                                _positionStamp = DateTime.UtcNow;
+                            }
+                        }
+                        break;
+
+                    case "playback":
+                        bool playing = root.TryGetProperty("status", out var statusEl) && statusEl.GetString() == "playing";
+                        lock (_lock)
+                        {
+                            _isPlaying = playing;
+                            _positionStamp = DateTime.UtcNow; // 冻结/恢复时重置插值基准，避免把暂停时长算进进度
+                        }
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"Just Solo LyricServer 消息解析失败: {ex.Message}");
+            }
+        }
+
+        private void ApplyLyrics(JsonElement root)
+        {
+            if (!root.TryGetProperty("lyrics", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            {
+                lock (_lock) _lyrics = Array.Empty<LyricLine>();
+                return;
+            }
+
+            var lines = new List<LyricLine>(arr.GetArrayLength());
+            foreach (var item in arr.EnumerateArray())
+            {
+                if (item.ValueKind != JsonValueKind.Object) continue;
+
+                int time = item.TryGetProperty("time", out var t) && t.TryGetInt32(out int tv) ? tv : 0;
+                string text = item.TryGetProperty("text", out var tx) ? tx.GetString() ?? "" : "";
+                string translation = item.TryGetProperty("translation", out var tr) ? tr.GetString() ?? "" : "";
+                lines.Add(new LyricLine(time, text, translation));
+            }
+
+            lock (_lock) _lyrics = lines.ToArray();
+        }
+    }
+}

--- a/JustSoloLyricClient.cs
+++ b/JustSoloLyricClient.cs
@@ -6,7 +6,7 @@ namespace NotchPeninsula
 {
     /// <summary>
     /// Just Solo LyricServer（ws://127.0.0.1:47290）客户端。
-    /// 单向接收 init / progress / playback 推送，供本地歌词高亮使用。
+    /// 单向接收 init / progress / playback / spectrum 推送，供本地歌词高亮与频谱显示使用。
     /// 协议文档：Just-Solo-LyricServer.md
     /// </summary>
     internal sealed class JustSoloLyricClient
@@ -16,6 +16,8 @@ namespace NotchPeninsula
         private const int MaxReconnectDelayMs = 30000;
         // Just Solo 自身高亮使用的默认歌词预读偏移（client 需自行补偿才能与其同步）
         private const float DefaultLyricPreReadSeconds = 0.13f;
+        // 超过该时长未收到 spectrum 即视为无数据（服务端推送周期 100ms），回退到本地音频采集
+        private const double SpectrumStaleMs = 500d;
 
         private readonly record struct LyricLine(int Time, string Text, string Translation);
 
@@ -24,6 +26,8 @@ namespace NotchPeninsula
         private int _position;
         private DateTime _positionStamp = DateTime.UtcNow;
         private bool _isPlaying;
+        private float[] _spectrum = Array.Empty<float>();
+        private DateTime _spectrumStamp = DateTime.MinValue;
 
         private volatile bool _running;   // 是否期望保持连接
         private volatile bool _connected; // 当前是否已连接
@@ -114,6 +118,25 @@ namespace NotchPeninsula
             return true;
         }
 
+        /// <summary>
+        /// 读取 LyricServer 推送的实时频谱（协议 v1.2.0+，12 频段，0.0~1.0，低频→高频）。
+        /// 返回 false 表示未连接、服务端不支持（v1.2.0 之前）或当前无频谱数据，调用方应回退到本地音频采集。
+        /// </summary>
+        public bool TryGetSpectrum(out float[] bands)
+        {
+            bands = Array.Empty<float>();
+
+            lock (_lock)
+            {
+                if (!_connected) return false;
+                if (_spectrum.Length == 0) return false;
+                if ((DateTime.UtcNow - _spectrumStamp).TotalMilliseconds > SpectrumStaleMs) return false;
+
+                bands = _spectrum;
+                return true;
+            }
+        }
+
         private void ResetState()
         {
             lock (_lock)
@@ -122,6 +145,8 @@ namespace NotchPeninsula
                 _position = 0;
                 _positionStamp = DateTime.UtcNow;
                 _isPlaying = false;
+                _spectrum = Array.Empty<float>();
+                _spectrumStamp = DateTime.MinValue;
             }
         }
 
@@ -227,7 +252,17 @@ namespace NotchPeninsula
                         {
                             _isPlaying = playing;
                             _positionStamp = DateTime.UtcNow; // 冻结/恢复时重置插值基准，避免把暂停时长算进进度
+                            if (!playing)
+                            {
+                                // 暂停/停止后服务端不再推送频谱，直接失效以免残留最后一帧
+                                _spectrum = Array.Empty<float>();
+                                _spectrumStamp = DateTime.MinValue;
+                            }
                         }
+                        break;
+
+                    case "spectrum":
+                        ApplySpectrum(root);
                         break;
                 }
             }
@@ -257,6 +292,31 @@ namespace NotchPeninsula
             }
 
             lock (_lock) _lyrics = lines.ToArray();
+        }
+
+        private void ApplySpectrum(JsonElement root)
+        {
+            // 空数组表示刚恢复播放、缓冲未填满，按"暂无数据"处理
+            if (!root.TryGetProperty("bands", out var arr) || arr.ValueKind != JsonValueKind.Array || arr.GetArrayLength() == 0)
+            {
+                lock (_lock)
+                {
+                    _spectrum = Array.Empty<float>();
+                    _spectrumStamp = DateTime.MinValue;
+                }
+                return;
+            }
+
+            var bands = new float[arr.GetArrayLength()];
+            int i = 0;
+            foreach (var el in arr.EnumerateArray())
+                bands[i++] = el.ValueKind == JsonValueKind.Number && el.TryGetSingle(out float v) ? v : 0f;
+
+            lock (_lock)
+            {
+                _spectrum = bands;
+                _spectrumStamp = DateTime.UtcNow;
+            }
         }
     }
 }

--- a/MediaController.cs
+++ b/MediaController.cs
@@ -307,6 +307,12 @@ namespace NotchPeninsula
         public async void Next() => await _currentSession?.TrySkipNextAsync();
         public async void Previous() => await _currentSession?.TrySkipPreviousAsync();
 
+        /// <summary>
+        /// 获取 Just Solo LyricServer 推送的实时频谱（12 频段，低频→高频）。
+        /// 返回 false 表示不可用（未连接 / 服务端版本过低 / 无数据），调用方应回退到本地音频采集。
+        /// </summary>
+        public bool TryGetSoloSpectrum(out float[] bands) => _justSoloLyric.TryGetSpectrum(out bands);
+
         private async void OnMediaPropertiesChanged(GlobalSystemMediaTransportControlsSession sender, MediaPropertiesChangedEventArgs args)
         {
             await RefreshProperties();

--- a/MediaController.cs
+++ b/MediaController.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Text.RegularExpressions;
 using Windows.Media.Control;
 using SkiaSharp;
@@ -45,6 +45,8 @@ namespace NotchPeninsula
         private bool _isBilibiliSession;  // 通用模式下当前会话是否为 bilibili，用于隐藏 Artist
         private bool _isPotPlayerSession; // 当前会话是否为 PotPlayer，无歌名/歌手时隐藏文本
         private bool _isBrowserSession;   // 当前会话是否为浏览器 (Chrome/Edge)，启用视频标题清理
+        private bool _isJustSoloSession;  // 当前会话是否为 Just Solo，启用 LyricServer 直连歌词
+        private readonly JustSoloLyricClient _justSoloLyric = new();
 
         public MediaController()
         {
@@ -120,6 +122,10 @@ namespace NotchPeninsula
             _isPotPlayerSession = MediaLogoProvider.IsPlatform(newSession?.SourceAppUserModelId, "PotPlayer");
             _isBrowserSession = MediaLogoProvider.IsPlatform(newSession?.SourceAppUserModelId, "Chrome")
                              || MediaLogoProvider.IsPlatform(newSession?.SourceAppUserModelId, "Edge");
+            _isJustSoloSession = newSession?.SourceAppUserModelId?.Contains("justsolo", StringComparison.OrdinalIgnoreCase) == true;
+
+            // Just Solo 专属歌词通道：仅通用模式下检测到 justsolo 会话时才连接 LyricServer
+            UpdateJustSoloConnection();
 
             // 如果目标会话没变，只需刷新属性，避免重复订阅事件浪费内存
             if (_currentSession != null && newSession != null && _currentSession.SourceAppUserModelId == newSession.SourceAppUserModelId)
@@ -156,6 +162,21 @@ namespace NotchPeninsula
                 IsPlaying = false;
                 Thumbnail?.Dispose();
                 Thumbnail = null;
+            }
+        }
+
+        // 依据当前会话与平台模式，维护 Just Solo LyricServer 的连接
+        private void UpdateJustSoloConnection()
+        {
+            bool shouldConnect = TargetPlatform == "other" && _isJustSoloSession;
+
+            if (shouldConnect)
+            {
+                if (!_justSoloLyric.IsRunning) _justSoloLyric.Start();
+            }
+            else if (_justSoloLyric.IsRunning)
+            {
+                _justSoloLyric.Stop();
             }
         }
 
@@ -485,6 +506,14 @@ namespace NotchPeninsula
 
             // 拦截无效会话，但不再在这里拦截空歌词
             if (_currentSession == null) { CurrentLyric = ""; return; }
+
+            // Just Solo LyricServer 直连歌词优先（仅通用模式下检测到 justsolo 会话时才会处于连接状态）
+            if (_justSoloLyric.TryGetCurrentLyric(LyricDelayOffset, out string soloText, out float soloProgress))
+            {
+                CurrentLyric = IsLyricsEnabled ? soloText : "";
+                CurrentLyricProgress = IsLyricsEnabled ? soloProgress : 0f;
+                return;
+            }
 
             try
             {

--- a/NotchWindow.cs
+++ b/NotchWindow.cs
@@ -64,7 +64,8 @@ namespace NotchPeninsula
         private readonly DateTime _appStartTime = DateTime.Now;
         private readonly AudioAnalyzer _audioAnalyzer;
         private float[] _currentBars = new float[5]; // 用于渲染线程的平滑过渡
-        private readonly float[] _spectrumBars = new float[5]; // LyricServer 12 频段压缩为 5 柱时的复用缓冲
+        private readonly float[] _spectrumBars = new float[5]; // LyricServer 12 频段压缩为 5 柱的复用缓冲（仅 RenderLoop 单线程内写入并当帧消费）
+        private bool _wasUsingSoloSpectrum; // 上一帧是否在用 LyricServer 频谱，用于感知独占播放结束
         private readonly System.Windows.Forms.NotifyIcon _notifyIcon; // 托盘与自启常量
         private const string AppName = "NotchPeninsula";
         private static System.Windows.Forms.ToolStripMenuItem? _autoStartItem; // 提权为静态，方便全局同步
@@ -195,6 +196,7 @@ namespace NotchPeninsula
                     _notifyIcon.Dispose();
                 }
                 Info("程序退出");
+                _audioAnalyzer.Dispose(); // 停掉看门狗并释放捕获/COM 订阅
                 Environment.Exit(0);
             };
 
@@ -585,9 +587,12 @@ namespace NotchPeninsula
 
             // 频谱优先取 Just Solo LyricServer 推送（独占音频输出时本地采集拿不到数据），
             // 不可用（未连接 / 服务端不支持 / 已暂停）时回退到原来的 WASAPI 采集
-            float[] targetBars = _media.TryGetSoloSpectrum(out float[] soloBands) && soloBands.Length >= 12
-                ? MapSoloSpectrum(soloBands)
-                : _audioAnalyzer.GetBars();
+            bool useSoloSpectrum = _media.TryGetSoloSpectrum(out float[] soloBands) && soloBands.Length >= 12;
+            if (_wasUsingSoloSpectrum && !useSoloSpectrum)
+                _audioAnalyzer.EnsureCaptureAlive(); // LyricServer 频谱刚结束，让它立即复核本地采集
+            _wasUsingSoloSpectrum = useSoloSpectrum;
+
+            float[] targetBars = useSoloSpectrum ? MapSoloSpectrum(soloBands) : _audioAnalyzer.GetBars();
             for (int i = 0; i < 5; i++)
             {
                 float target = targetBars[i];
@@ -628,7 +633,9 @@ namespace NotchPeninsula
             }
         }
 
-        // 把 LyricServer 的 12 个频段（低频→高频）按区间取峰值压缩为渲染层的 5 根柱
+        // 把 LyricServer 的 12 个频段（低频→高频）按区间取峰值压缩为渲染层的 5 根柱。
+        // 返回复用缓冲以避免每帧分配；调用方只有 RenderLoop，且它由 _isRendering 保证串行执行，
+        // 写入后当帧立即被消费，不存在跨线程/跨帧共享。
         private float[] MapSoloSpectrum(float[] bands)
         {
             _spectrumBars[0] = Math.Max(bands[0], bands[1]);

--- a/NotchWindow.cs
+++ b/NotchWindow.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using SkiaSharp;
 using Microsoft.Win32;
@@ -64,6 +64,7 @@ namespace NotchPeninsula
         private readonly DateTime _appStartTime = DateTime.Now;
         private readonly AudioAnalyzer _audioAnalyzer;
         private float[] _currentBars = new float[5]; // 用于渲染线程的平滑过渡
+        private readonly float[] _spectrumBars = new float[5]; // LyricServer 12 频段压缩为 5 柱时的复用缓冲
         private readonly System.Windows.Forms.NotifyIcon _notifyIcon; // 托盘与自启常量
         private const string AppName = "NotchPeninsula";
         private static System.Windows.Forms.ToolStripMenuItem? _autoStartItem; // 提权为静态，方便全局同步
@@ -582,7 +583,11 @@ namespace NotchPeninsula
                 startupProgress = (float)(1.0 - (invT * invT * invT));
             }
 
-            var targetBars = _audioAnalyzer.GetBars();
+            // 频谱优先取 Just Solo LyricServer 推送（独占音频输出时本地采集拿不到数据），
+            // 不可用（未连接 / 服务端不支持 / 已暂停）时回退到原来的 WASAPI 采集
+            float[] targetBars = _media.TryGetSoloSpectrum(out float[] soloBands) && soloBands.Length >= 12
+                ? MapSoloSpectrum(soloBands)
+                : _audioAnalyzer.GetBars();
             for (int i = 0; i < 5; i++)
             {
                 float target = targetBars[i];
@@ -621,6 +626,17 @@ namespace NotchPeninsula
                 // 渲染安全结束，释放标记，允许下一帧进入
                 System.Threading.Interlocked.Exchange(ref _isRendering, 0);
             }
+        }
+
+        // 把 LyricServer 的 12 个频段（低频→高频）按区间取峰值压缩为渲染层的 5 根柱
+        private float[] MapSoloSpectrum(float[] bands)
+        {
+            _spectrumBars[0] = Math.Max(bands[0], bands[1]);
+            _spectrumBars[1] = Math.Max(bands[2], Math.Max(bands[3], bands[4]));
+            _spectrumBars[2] = Math.Max(bands[5], bands[6]);
+            _spectrumBars[3] = Math.Max(bands[7], Math.Max(bands[8], bands[9]));
+            _spectrumBars[4] = Math.Max(bands[10], bands[11]);
+            return _spectrumBars;
         }
 
         private void UpdateWindow()

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,92 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    NotchPeninsula 打包脚本：清理构建产物，发布为不打包运行时的单文件 exe。
+
+.DESCRIPTION
+    不打包 .NET 运行时（目标机需自备 .NET 10 Desktop Runtime，否则会提示 "You must install .NET"），
+    只把程序自身、依赖 dll（NAudio / SkiaSharp / WinRT 等）和资源文件
+    （data 图片、vcruntime140.dll、msvcp140.dll 等）全部合并进单个 exe，
+    直接输出到 publish 目录，产物约 35 MB。
+
+.PARAMETER Clean
+    仅清理构建产物，不执行打包。
+
+.PARAMETER Output
+    发布输出目录（相对仓库根目录），默认 publish。
+
+.EXAMPLE
+    .\build.ps1
+    清理后打包，产出 publish\NotchPeninsula.exe（约 35 MB）。
+
+.EXAMPLE
+    .\build.ps1 -Clean
+    只清理 bin/obj/publish，不打包。
+#>
+[CmdletBinding()]
+param(
+    [switch]$Clean,
+
+    [string]$Output = 'publish'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$root = $PSScriptRoot
+$project = Join-Path $root 'NotchPeninsula.csproj'
+$outDir = Join-Path $root $Output
+
+function Remove-Path($path) {
+    if (Test-Path $path) {
+        Remove-Item -Recurse -Force $path
+        Write-Host "  已删除 $path" -ForegroundColor DarkGray
+    }
+}
+
+function Remove-BuildArtifacts {
+    # 清理编译产物与上一次的发布结果
+    Remove-Path (Join-Path $root 'bin')
+    Remove-Path (Join-Path $root 'obj')
+    Remove-Path $outDir
+}
+
+# 本程序常驻托盘，从 bin 下运行时会把产物锁住，导致清理失败
+$running = @(Get-Process -Name 'NotchPeninsula' -ErrorAction SilentlyContinue)
+if ($running.Count -gt 0) {
+    throw "检测到 NotchPeninsula 正在运行（PID: $($running.Id -join ', ')），请先从托盘菜单退出，再执行本脚本。"
+}
+
+Write-Host '清理构建产物...' -ForegroundColor Cyan
+Remove-BuildArtifacts
+
+if ($Clean) {
+    Write-Host '清理完成（-Clean 未执行打包）' -ForegroundColor Green
+    return
+}
+
+# 框架依赖单文件：不含 .NET 运行时，但把托管依赖、原生库与 data 资源一并塞进 exe
+$publishArgs = @(
+    $project
+    '-c', 'Release'
+    '-r', 'win-x64'
+    '--self-contained', 'false'
+    '-p:PublishSingleFile=true'
+    '-p:IncludeNativeLibrariesForSelfExtract=true'
+    '-p:IncludeAllContentForSelfExtract=true'
+)
+
+Write-Host '开始打包...' -ForegroundColor Cyan
+& dotnet publish @publishArgs -o $outDir
+if ($LASTEXITCODE -ne 0) { throw "dotnet publish 失败，退出码 $LASTEXITCODE" }
+
+# 发布产物已落在 $outDir，bin/obj 只是编译中间产物，丢掉保持仓库干净
+Remove-Path (Join-Path $root 'bin')
+Remove-Path (Join-Path $root 'obj')
+
+$exe = Join-Path $outDir 'NotchPeninsula.exe'
+if (-not (Test-Path $exe)) { throw "未找到发布产物：$exe" }
+
+$sizeMb = [math]::Round((Get-Item $exe).Length / 1MB, 2)
+Write-Host ''
+Write-Host "打包完成：$exe（$sizeMb MB）" -ForegroundColor Green
+Write-Host '提示：未打包 .NET 运行时，目标机需已安装 .NET 10 Desktop Runtime。' -ForegroundColor Yellow


### PR DESCRIPTION
# PR: Just Solo LyricServer 直连（歌词 + 实时频谱）+ 音频捕获独占自愈

## 背景 / 动机

1. Just Solo 内置了 LyricServer（`ws://127.0.0.1:47290`），可推送与自身高亮完全同步的歌词，官方 Lyrics API 存在延迟与切歌不一致问题，需要直连以提升高亮精度。
2. 播放器以 **独占模式（WASAPI Exclusive）** 占用输出设备时，本进程 Loopback 采集会被系统断开，频谱柱永久变 0；原实现仅在构造时启动一次捕获，断开后不会恢复。
3. LyricServer v1.2.0+ 已推送 `spectrum` 实时频谱，可在独占场景下替代本地采集。

## 变更内容

### 1. Just Solo 歌词直连 (`0a09e1c`)

- 新增 [JustSoloLyricClient.cs](file:///f:/Coding/1-Code/NotchPeninsula/JustSoloLyricClient.cs)：WebSocket 客户端，指数退避重连（1s→30s），发送 `hello` 声明客户端名，解析 `init` / `progress` / `playback` 推送。
  - 回退 `progress` 400ms 推送间隔：用经过时间做线性插值 + 二分查找当前行，保证高亮平滑；`DefaultLyricPreReadSeconds = 0.13s` 与 Just Solo 自身高亮对齐，并叠加用户延迟偏移。
  - 暂停/恢复时重置插值基准，避免把暂停时长算进进度。
- 新增 [Just-Solo-LyricServer.md](file:///f:/Coding/1-Code/NotchPeninsula/Just-Solo-LyricServer.md)：协议文档（消息格式、故障排查、版本历史）。
- [MediaController.cs](file:///f:/Coding/1-Code/NotchPeninsula/MediaController.cs)：检测 `justsolo` 会话（仅通用平台模式）时按需 `Start()`/`Stop()` 连接；歌词取值时 LyricServer 直连优先，不可用则回退原有来源。

### 2. LyricServer 实时频谱支持 (`c49f079`)

- [JustSoloLyricClient.cs](file:///f:/Coding/1-Code/NotchPeninsula/JustSoloLyricClient.cs)：解析新增 `spectrum` 推送（12 频段，0.0~1.0，低频→高频），新增 `TryGetSpectrum()`；超过 500ms 未收到即视为过期（服务端周期 100ms），暂停/停止或空数组时主动失效，避免残留最后一帧。
- [MediaController.cs](file:///f:/Coding/1-Code/NotchPeninsula/MediaController.cs)：透出 `TryGetSoloSpectrum()`。
- [NotchWindow.cs](file:///f:/Coding/1-Code/NotchPeninsula/NotchWindow.cs)：渲染时优先取推送频谱，否则回退 WASAPI 采集；新增 `MapSoloSpectrum()` 按区间取峰值，将 12 频段压缩为渲染层的 5 根柱（复用缓冲，避免每帧分配）。

### 3. 音频捕获重构，修复独占模式失效 (`15c51b1`)

- [AudioAnalyzer.cs](file:///f:/Coding/1-Code/NotchPeninsula/AudioAnalyzer.cs)：
  - **常驻看门狗**：每 500ms 做一次 ~0.04µs 的健康检查（捕获状态 + 1500ms 无数据判定失效），判定失效后限速重建（最小间隔 1s，单次约 7ms），恢复延迟通常在一个检查周期内。
  - **Core Audio 事件订阅**：`IMMNotificationClient` 感知设备增删/状态/默认设备变化；`IAudioSessionEventsHandler` 感知本进程捕获会话被独占抢占/格式变更/设备移除，事件到达即唤醒看门狗立即复核（跳过限速）。
  - **线程模型**：释放/重建固定在看门狗线程串行执行，避免在 COM 回调线程与捕获线程做耗时操作；单轮异常不退出循环，丢弃当前捕获后继续，杜绝"看门狗静默死亡导致频谱永久失效"。
  - **资源管理**：实现 `IDisposable`（可重复调用），退出时停看门狗、注销会话与设备事件订阅、释放捕获与 COM 引用（音量/会话回调需持有引用否则被回收）；初始化失败释放半成品捕获避免句柄泄漏，重试失败降为 Debug 日志防刷屏。
- [NotchWindow.cs](file:///f:/Coding/1-Code/NotchPeninsula/NotchWindow.cs)：退出流程调用 `_audioAnalyzer.Dispose()`；新增 `_wasUsingSoloSpectrum` 状态，LyricServer 频谱刚结束（独占播放结束）时主动 `EnsureCaptureAlive()`，让本地采集立即复核恢复。

## 影响范围

- 歌词来源优先级：LyricServer 直连 > 原有来源；频谱来源优先级：LyricServer 推送 > 本地 WASAPI 采集，两条路径无缝切换。
- 行为变化：独占播放时歌词/频谱均能正常显示；播放暂停时不再残留旧频谱帧。
- 兼容性：Just Solo 未运行、服务端版本低于 v1.2.0、非 `justsolo` 会话或非通用平台模式下，行为与旧版一致（回退原逻辑）。

## 验证建议

- 播放 Just Solo 并切歌：歌词高亮与 Just Solo 自身一致，进度平滑无跳变。
- 普通播放：频谱正常，LyricServer 与本地采集来回切换无跳变。
- 独占模式播放：频谱仍能显示（走推送路径）；退出独占后本地采集在约 1 个检查周期内自动恢复。
- 拔插/切换默认输出设备、切换独占与非独占：无异常日志，频谱自动恢复。
- 退出程序：无残留进程/句柄，日志输出"音频分析器已释放"。