### PR TITLE
refactor(renderer, window): 统一弹窗最大宽度，调整剪贴板弹窗逻辑

### DIFF
--- a/NotchWindow.cs
+++ b/NotchWindow.cs
@@ -57,8 +57,9 @@ namespace NotchPeninsula
 
         // 剪贴板链接状态控制
         private string? _currentClipboardLink;
+        private string? _pendingClipboardLink; // 通知优先时的单槽等待位（仅存引用，不额外分配队列内存）
         private DateTime _clipboardEndTime;
-        private const double ClipboardLinkDurationSeconds = 6; // 链接展示时长
+        private const double ClipboardLinkDurationSeconds = 3; // 链接展示时长
         // 提取文本中第一个 http/https 链接（沿用 RFC3986 合法字符集，天然在中文/空格处截断）
         private static readonly System.Text.RegularExpressions.Regex ClipboardLinkRegex =
             new(@"https?://[A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=%]+",
@@ -257,6 +258,15 @@ namespace NotchPeninsula
             clicked_info = false;
             if (!_dispatcher.CheckAccess()) { _dispatcher.Invoke(() => OnToastDetected(toast)); return; }
 
+            // 通知优先级高于剪贴板：若链接岛正在展示，先让位给通知，等通知结束后再补展示
+            if (!string.IsNullOrEmpty(_currentClipboardLink))
+            {
+                _pendingClipboardLink = _currentClipboardLink;
+                _currentClipboardLink = null;
+                Renderer.ClipboardButtonHovered = false;
+                _isCursorOverIcon = false;
+            }
+
             _currentToast = toast;
             _toastEndTime = DateTime.Now.AddSeconds(4); // 消息展示4秒自动消失
         }
@@ -295,14 +305,23 @@ namespace NotchPeninsula
         {
             // 同一个链接若正在展示中，不重复触发动画
             if (link == _currentClipboardLink && DateTime.Now < _clipboardEndTime) return;
+            if (link == _pendingClipboardLink) return;
+
+            // 通知优先级更高：通知展示期间先放入等待位，待通知结束后再展示
+            if (_currentToast != null && DateTime.Now < _toastEndTime)
+            {
+                _pendingClipboardLink = link;
+                Info($"检测到剪贴板链接，等待通知结束后展示：{link}");
+                return;
+            }
 
             _currentClipboardLink = link;
             _clipboardEndTime = DateTime.Now.AddSeconds(ClipboardLinkDurationSeconds);
             Info($"检测到剪贴板链接：{link}");
         }
 
-        // 链接岛是否处于展示期
-        private bool IsClipboardLinkActive() => IsClipboardLinkEnabled && !string.IsNullOrEmpty(_currentClipboardLink) && DateTime.Now < _clipboardEndTime;
+        // 链接岛是否处于展示期（通知优先，通知展示期间链接岛让位）
+        private bool IsClipboardLinkActive() => IsClipboardLinkEnabled && !isToastActive && !string.IsNullOrEmpty(_currentClipboardLink) && DateTime.Now < _clipboardEndTime;
 
         // 判断逻辑坐标是否落在链接岛右侧的跳转按钮上
         private bool IsOverClipboardButton(int mx, int my)
@@ -476,6 +495,13 @@ namespace NotchPeninsula
 
                 // 判断当前 Toast 是否处于激活期
                 isToastActive = _currentToast != null && DateTime.Now < _toastEndTime;
+                // 消息队列：通知优先级最高，通知结束后把等待位中的链接提升为展示（3s 计时从此刻开始）
+                if (!isToastActive && _pendingClipboardLink != null)
+                {
+                    _currentClipboardLink = _pendingClipboardLink;
+                    _pendingClipboardLink = null;
+                    _clipboardEndTime = DateTime.Now.AddSeconds(ClipboardLinkDurationSeconds);
+                }
                 // 判断剪贴板链接是否处于激活期
                 bool isClipboardActive = IsClipboardLinkActive();
                 // 实时穿透与 0% 透明度智能判定
@@ -602,7 +628,7 @@ namespace NotchPeninsula
                     float requiredWidth = textWidth + 115f;
                     if (requiredWidth > expectedTargetWidth) expectedTargetWidth = requiredWidth;
                 }
-                float expectedTargetHeight = isClipboardActive ? Renderer.CLIPBOARD_HEIGHT
+                float expectedTargetHeight = isClipboardActive ? Renderer.MEDIA_HEIGHT
                     : (isToastActive ? Renderer.TOAST_HEIGHT : (currentActive ? (Renderer.IsMediaExpanded ? 130f : Renderer.MEDIA_HEIGHT) : Renderer.BASE_HEIGHT));
 
                 // 形态(刘海/灵动岛) 弹簧物理插值引擎

--- a/Renderer.cs
+++ b/Renderer.cs
@@ -56,30 +56,31 @@ namespace NotchPeninsula
             if (string.IsNullOrEmpty(text)) return 0;
             return _textPaint.MeasureText(text);
         }
-        // 计算Toast消息自适应宽度，限制最大500px
+        // 消息类弹窗（通知/剪贴板）统一的最大宽度，保证两者最长时一致
+        private const float MESSAGE_MAX_WIDTH = 800f;
+        // 计算Toast消息自适应宽度
         public static float GetToastAutoWidth()
         {
             float maxTextW = Math.Max(_cachedToastTitleWidth, _cachedToastBodyWidth);
-            return Math.Min(Math.Max(TOAST_WIDTH, maxTextW + 68f), 800f);
+            return Math.Min(Math.Max(TOAST_WIDTH, maxTextW + 68f), MESSAGE_MAX_WIDTH);
         }
         public static bool IsMediaExpanded = false;
         public static int HoveredExpandedButton = -1; // -1:无, 0:上一首, 1:播放/暂停, 2:下一首
 
-        // ===== 剪贴板链接岛 =====
-        public const float CLIPBOARD_HEIGHT = 44f;   // 链接岛高度
-        public const float CLIPBOARD_ICON = 26f;     // 左侧剪贴板图标边长
-        public const float CLIPBOARD_BTN = 26f;      // 右侧跳转按钮边长
+        // ===== 剪贴板链接岛（高度与媒体控制器同款 MEDIA_HEIGHT，宽度随内容自适应）=====
+        public const float CLIPBOARD_ICON = 20f;     // 左侧通知图标边长
+        public const float CLIPBOARD_BTN = 20f;      // 右侧跳转按钮边长
         public const float CLIPBOARD_PAD = 12f;      // 左右外边距
         public static bool ClipboardButtonHovered = false; // 跳转按钮是否处于悬停
         private static SKBitmap? _clipboardIcon;
         private static SKBitmap? _openLinkIcon;
 
-        // 链接岛自适应宽度：左图标 + 间距 + 文本 + 间距 + 跳转按钮，并限制最大宽度防止岛体过长
+        // 链接岛宽度随链接内容自适应：左图标 + 间距 + 文本 + 间距 + 跳转按钮，最长与消息显示的最长宽度一致
         public static float GetClipboardAutoWidth(string? link)
         {
             float textW = string.IsNullOrEmpty(link) ? 0f : _textPaint.MeasureText(link);
             float width = CLIPBOARD_PAD + CLIPBOARD_ICON + 10f + textW + 10f + CLIPBOARD_BTN + CLIPBOARD_PAD;
-            return Math.Min(Math.Max(width, 176f), 520f);
+            return Math.Min(Math.Max(width, 176f), MESSAGE_MAX_WIDTH);
         }
         private static readonly SKPaint _hoverCirclePaint = new() { IsAntialias = true }; // 零 GC 纯色画笔
         private static SKColor _currentTextColor = SKColors.White;


### PR DESCRIPTION
refactor(renderer, window): 统一弹窗最大宽度，调整剪贴板弹窗逻辑
- 提取统一的消息弹窗最大宽度常量MESSAGE_MAX_WIDTH
- 调整剪贴板链接岛图标尺寸与注释
- 新增通知优先的剪贴板等待队列逻辑
- 缩短剪贴板链接展示时长至3秒
- 修复剪贴板高度引用错误