### PR TITLE
build: 修复单文件发布下插件加载失效的问题

### DIFF
--- a/Plugin/PluginLoader.cs
+++ b/Plugin/PluginLoader.cs
@@ -11,7 +11,7 @@ public static class PluginLoader
     public static List<INotchPlugin> LoadAll(PluginHost host, string? pluginsRoot = null)
     {
         var loaded = new List<INotchPlugin>();
-        pluginsRoot ??= Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "plugins");
+        pluginsRoot ??= Path.Combine(GetAppDirectory(), "plugins");
         if (!Directory.Exists(pluginsRoot))
         {
             Logger.Info($"[PluginLoader] 插件目录不存在: {pluginsRoot}");
@@ -69,6 +69,20 @@ public static class PluginLoader
         }
 
         return loaded;
+    }
+
+    /// <summary>exe 所在目录：单文件发布时 AppContext.BaseDirectory 是临时解压目录，插件必须放 exe 同级，故优先取进程自身路径。</summary>
+    private static string GetAppDirectory()
+    {
+        var exe = Environment.ProcessPath;
+        // 通过 dotnet NotchPeninsula.dll 启动时，进程路径是 dotnet.exe，此时回退到程序集目录
+        if (!string.IsNullOrEmpty(exe) &&
+            !Path.GetFileNameWithoutExtension(exe).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            var dir = Path.GetDirectoryName(exe);
+            if (!string.IsNullOrEmpty(dir)) return dir;
+        }
+        return AppContext.BaseDirectory;
     }
 
     /// <summary>插件加载上下文：优先从插件目录加载依赖，否则回退默认解析。</summary>

--- a/build.ps1
+++ b/build.ps1
@@ -86,7 +86,19 @@ Remove-Path (Join-Path $root 'obj')
 $exe = Join-Path $outDir 'NotchPeninsula.exe'
 if (-not (Test-Path $exe)) { throw "未找到发布产物：$exe" }
 
+# 插件不参与单文件打包（PluginLoader 从 exe 同级的 plugins\ 目录加载），需随发布产物一起部署
+$pluginsSrc = Join-Path $root 'plugins'
+$pluginsDst = Join-Path $outDir 'plugins'
+if (Test-Path $pluginsSrc) {
+    Remove-Path $pluginsDst
+    Copy-Item -Recurse -Force $pluginsSrc $pluginsDst
+    Write-Host "已复制插件目录：$pluginsDst" -ForegroundColor Cyan
+} else {
+    Write-Host '未找到 plugins 目录，发布产物将不含任何插件。' -ForegroundColor Yellow
+}
+
 $sizeMb = [math]::Round((Get-Item $exe).Length / 1MB, 2)
 Write-Host ''
 Write-Host "打包完成：$exe（$sizeMb MB）" -ForegroundColor Green
 Write-Host '提示：未打包 .NET 运行时，目标机需已安装 .NET 10 Desktop Runtime。' -ForegroundColor Yellow
+Write-Host "提示：分发时需把 $outDir\plugins 与 exe 放在同一目录，否则插件不会加载。" -ForegroundColor Yellow


### PR DESCRIPTION
调整插件目录加载逻辑，适配单文件发布场景，同时在构建脚本中自动复制插件目录到输出路径，并添加相关提示信息